### PR TITLE
Taskify Business 1.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "npm": "^11.6.0"
       },
       "devDependencies": {
-        "electron": "^38.0.0",
+        "electron": "^38.1.0",
         "electron-builder": "^26.0.12"
       }
     },
@@ -2261,9 +2261,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "38.0.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-38.0.0.tgz",
-      "integrity": "sha512-egljptiPJqbL/oamFCEY+g3RNeONWTVxZSGeyLqzK8xq106JhzuxnhJZ3sxt4DzJFaofbGyGJA37Oe9d+gVzYw==",
+      "version": "38.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-38.1.0.tgz",
+      "integrity": "sha512-ypA8GF8RU4HD5pA1sa0/2U8k+92EPP2c7pX+3XbgB760F7OmqrFXtYkOilVw6HfV4+lk88XxqigmsUKTACQYoQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "package.json"
   ],
   "devDependencies": {
-    "electron": "^38.0.0",
+    "electron": "^38.1.0",
     "electron-builder": "^26.0.12"
   },
   "dependencies": {


### PR DESCRIPTION
# Release Notes for Taskify Business 1.7.3

# Stack Upgrades

- Electron `38.0.0`
  - [New in 38.0.0](https://github.com/electron/electron/releases/tag/v38.0.0)
- Supabase-js `2.57`
  - [New in 2.57](https://github.com/supabase/supabase-js/releases/tag/v2.57)
  - dotenv `17.2.2`
  - [New in 17.2.2](https://www.npmjs.com/package/dotenv)

# Bug Fixes
[a30ce42] Fixed a bug where the version is not show proprerly.